### PR TITLE
0.10.40 0.12.7

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:jessie
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.10.39
+ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.11.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \

--- a/0.10/onbuild/Dockerfile
+++ b/0.10/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10.39
+FROM node:0.10.40
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.10.39
+ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.11.3
 
 RUN buildDeps='curl ca-certificates' \

--- a/0.10/wheezy/Dockerfile
+++ b/0.10/wheezy/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:wheezy
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.10.39
+ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.11.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:jessie
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.12.6
+ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.11.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \

--- a/0.12/onbuild/Dockerfile
+++ b/0.12/onbuild/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.6
+FROM node:0.12.7
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.12.6
+ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.11.3
 
 RUN buildDeps='curl ca-certificates' \

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -5,7 +5,7 @@ FROM buildpack-deps:wheezy
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.12.6
+ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.11.3
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \


### PR DESCRIPTION
Test build looks good:

```
[christopher@JoyentMacBookPro ~/GitHub/docker-node]$ ./test-build.sh 
Building 0.10.40...
Sending build context to Docker daemon 8.704 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:jessie
 ---> 4b708e6c0f6c
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 9d3a855fe348
Step 2 : ENV NODE_VERSION 0.10.40
 ---> Using cache
 ---> 206e81a33d36
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> 9eb2c443f777
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> ea86cd34526f
Step 5 : CMD node
 ---> Using cache
 ---> 8f093a1a16fd
Successfully built 8f093a1a16fd
Build of 0.10.40 succeeded.
Building 0.10.40-onbuild variant...
Sending build context to Docker daemon 2.048 kB
Sending build context to Docker daemon 
Step 0 : FROM node:0.10.40
 ---> 8f093a1a16fd
Step 1 : RUN mkdir -p /usr/src/app
 ---> Using cache
 ---> d3c51992ba03
Step 2 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 8d3475fad6c2
Step 3 : ONBUILD copy package.json /usr/src/app/
 ---> Using cache
 ---> 15fc2fadb077
Step 4 : ONBUILD run npm install
 ---> Using cache
 ---> e426a992267f
Step 5 : ONBUILD copy . /usr/src/app
 ---> Using cache
 ---> 0a4bdb42d5a9
Step 6 : CMD npm start
 ---> Using cache
 ---> d9d298d036ea
Successfully built d9d298d036ea
Build of 0.10.40-onbuild succeeded.
Building 0.10.40-slim variant...
Sending build context to Docker daemon 3.072 kB
Sending build context to Docker daemon 
Step 0 : FROM debian:jessie
 ---> bf84c1d84a8f
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 57dfd9dddeda
Step 2 : ENV NODE_VERSION 0.10.40
 ---> Using cache
 ---> fc02ecff4470
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> a153903a7090
Step 4 : RUN buildDeps='curl ca-certificates' 	&& set -x 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends 	&& rm -rf /var/lib/apt/lists/* 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& apt-get purge -y --auto-remove $buildDeps 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> 472082d06b4e
Step 5 : CMD node
 ---> Using cache
 ---> b9c84c0b0058
Successfully built b9c84c0b0058
Build of 0.10.40-slim succeeded.
Building 0.10.40-wheezy variant...
Sending build context to Docker daemon  2.56 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:wheezy
 ---> 5df2a0d3a53a
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> b92d50b9b816
Step 2 : ENV NODE_VERSION 0.10.40
 ---> Using cache
 ---> cc5e55dc085e
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> 78ac48904bac
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> 9fb9e19d997f
Step 5 : CMD node
 ---> Using cache
 ---> fe5a09846fa9
Successfully built fe5a09846fa9
Build of 0.10.40-wheezy succeeded.
Building 0.12.7...
Sending build context to Docker daemon 8.704 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:jessie
 ---> 4b708e6c0f6c
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 9d3a855fe348
Step 2 : ENV NODE_VERSION 0.12.7
 ---> Running in 9108333d104b
 ---> 92df471bb620
Removing intermediate container 9108333d104b
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Running in 4ca85c9b745c
 ---> 9abcf6f7e74a
Removing intermediate container 4ca85c9b745c
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Running in 758894602c38
 ---> 7be4effd8737
Removing intermediate container 758894602c38
Step 5 : CMD node
 ---> Running in 875566029dcb
 ---> a9995a32dd4b
Removing intermediate container 875566029dcb
Successfully built a9995a32dd4b
Build of 0.12.7 succeeded.
Building 0.12.7-onbuild variant...
Sending build context to Docker daemon 2.048 kB
Sending build context to Docker daemon 
Step 0 : FROM node:0.12.7
 ---> a9995a32dd4b
Step 1 : RUN mkdir -p /usr/src/app
 ---> Running in dd5f0cf56da1
 ---> a32daeb088b6
Removing intermediate container dd5f0cf56da1
Step 2 : WORKDIR /usr/src/app
 ---> Running in 478e2931b5fe
 ---> 69f529a54acc
Removing intermediate container 478e2931b5fe
Step 3 : ONBUILD copy package.json /usr/src/app/
 ---> Running in 6aa135f2d91a
 ---> 1a51bac76ffe
Removing intermediate container 6aa135f2d91a
Step 4 : ONBUILD run npm install
 ---> Running in 1c1516766d9c
 ---> 9e95551ccddc
Removing intermediate container 1c1516766d9c
Step 5 : ONBUILD copy . /usr/src/app
 ---> Running in 78153a27d2a4
 ---> 3eea0d471d5d
Removing intermediate container 78153a27d2a4
Step 6 : CMD npm start
 ---> Running in 5b2d3cb1f414
 ---> 351f09c4acf7
Removing intermediate container 5b2d3cb1f414
Successfully built 351f09c4acf7
Build of 0.12.7-onbuild succeeded.
Building 0.12.7-slim variant...
Sending build context to Docker daemon 3.072 kB
Sending build context to Docker daemon 
Step 0 : FROM debian:jessie
 ---> bf84c1d84a8f
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 57dfd9dddeda
Step 2 : ENV NODE_VERSION 0.12.7
 ---> Running in 0f11c55e26d0
 ---> e770ff9f6792
Removing intermediate container 0f11c55e26d0
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Running in 7ef6757d3458
 ---> 05e13eac3431
Removing intermediate container 7ef6757d3458
Step 4 : RUN buildDeps='curl ca-certificates' 	&& set -x 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends 	&& rm -rf /var/lib/apt/lists/* 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& apt-get purge -y --auto-remove $buildDeps 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Running in 51c89b733d28
 ---> bad5cd1b01dd
Removing intermediate container 51c89b733d28
Step 5 : CMD node
 ---> Running in 595feafb8310
 ---> 1f454adeedfc
Removing intermediate container 595feafb8310
Successfully built 1f454adeedfc
Build of 0.12.7-slim succeeded.
Building 0.12.7-wheezy variant...
Sending build context to Docker daemon  2.56 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:wheezy
 ---> 5df2a0d3a53a
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> b92d50b9b816
Step 2 : ENV NODE_VERSION 0.12.7
 ---> Running in 8c47ebe54487
 ---> c6de4d81c9f8
Removing intermediate container 8c47ebe54487
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Running in 78b8b95d0ceb
 ---> 98796595c04c
Removing intermediate container 78b8b95d0ceb
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Running in 416941e7801c
 ---> fbe537abb195
Removing intermediate container 416941e7801c
Step 5 : CMD node
 ---> Running in 496c7ecff16a
 ---> abab6ae14b29
Removing intermediate container 496c7ecff16a
Successfully built abab6ae14b29
Build of 0.12.7-wheezy succeeded.
Building 0.8.28...
Sending build context to Docker daemon 9.728 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:jessie
 ---> 4b708e6c0f6c
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 9d3a855fe348
Step 2 : ENV NODE_VERSION 0.8.28
 ---> Using cache
 ---> 916d24a2d23c
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> bf39d30cf70d
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@1.4.28 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> c2b5472b91dd
Step 5 : CMD node
 ---> Using cache
 ---> cce3d1d98257
Successfully built cce3d1d98257
Build of 0.8.28 succeeded.
Building 0.8.28-onbuild variant...
Sending build context to Docker daemon 2.048 kB
Sending build context to Docker daemon 
Step 0 : FROM node:0.8.28
 ---> cce3d1d98257
Step 1 : RUN mkdir -p /usr/src/app
 ---> Using cache
 ---> ea5be1b7de54
Step 2 : WORKDIR /usr/src/app
 ---> Using cache
 ---> 6efd04abefde
Step 3 : ONBUILD copy package.json /usr/src/app/
 ---> Using cache
 ---> d4b030e3eb7d
Step 4 : ONBUILD run npm install
 ---> Using cache
 ---> 5fe982f78ac3
Step 5 : ONBUILD copy . /usr/src/app
 ---> Using cache
 ---> 1498c7618bdd
Step 6 : CMD npm start
 ---> Using cache
 ---> a1172a669487
Successfully built a1172a669487
Build of 0.8.28-onbuild succeeded.
Building 0.8.28-slim variant...
Sending build context to Docker daemon 3.072 kB
Sending build context to Docker daemon 
Step 0 : FROM debian:jessie
 ---> bf84c1d84a8f
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> 57dfd9dddeda
Step 2 : ENV NODE_VERSION 0.8.28
 ---> Using cache
 ---> 09d08d6bfeaf
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> fdfc9c476341
Step 4 : RUN buildDeps='curl ca-certificates' 	&& set -x 	&& apt-get update && apt-get install -y $buildDeps --no-install-recommends 	&& rm -rf /var/lib/apt/lists/* 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& apt-get purge -y --auto-remove $buildDeps 	&& npm install -g npm@1.4.28 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> a30208aefc41
Step 5 : CMD node
 ---> Using cache
 ---> 19f518ae3364
Successfully built 19f518ae3364
Build of 0.8.28-slim succeeded.
Building 0.8.28-wheezy variant...
Sending build context to Docker daemon 3.072 kB
Sending build context to Docker daemon 
Step 0 : FROM buildpack-deps:wheezy
 ---> 5df2a0d3a53a
Step 1 : RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 ---> Using cache
 ---> b92d50b9b816
Step 2 : ENV NODE_VERSION 0.8.28
 ---> Using cache
 ---> 87edb8871c91
Step 3 : ENV NPM_VERSION 2.11.3
 ---> Using cache
 ---> 914ab2b1987b
Step 4 : RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" 	&& curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" 	&& gpg --verify SHASUMS256.txt.asc 	&& grep " node-v$NODE_VERSION-linux-x64.tar.gz\$" SHASUMS256.txt.asc | sha256sum -c - 	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 	&& rm "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt.asc 	&& npm install -g npm@1.4.28 	&& npm install -g npm@"$NPM_VERSION" 	&& npm cache clear
 ---> Using cache
 ---> df9283d6dc8d
Step 5 : CMD node
 ---> Using cache
 ---> 852680d79b0c
Successfully built 852680d79b0c
Build of 0.8.28-wheezy succeeded.
All builds successful!
```