### PR TITLE
Update "gpg" usage to be more resilient to transient failure

### DIFF
--- a/0.10/Dockerfile
+++ b/0.10/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.13.2

--- a/0.10/slim/Dockerfile
+++ b/0.10/slim/Dockerfile
@@ -3,7 +3,13 @@ FROM debian:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.13.2

--- a/0.10/wheezy/Dockerfile
+++ b/0.10/wheezy/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:wheezy
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.31/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.10.40
 ENV NPM_VERSION 2.13.2

--- a/0.12/Dockerfile
+++ b/0.12/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.13.2

--- a/0.12/slim/Dockerfile
+++ b/0.12/slim/Dockerfile
@@ -3,7 +3,13 @@ FROM debian:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.13.2

--- a/0.12/wheezy/Dockerfile
+++ b/0.12/wheezy/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:wheezy
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.13.2

--- a/0.8/Dockerfile
+++ b/0.8/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.8.28
 ENV NPM_VERSION 2.13.2

--- a/0.8/slim/Dockerfile
+++ b/0.8/slim/Dockerfile
@@ -3,7 +3,13 @@ FROM debian:jessie
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.8.28
 ENV NPM_VERSION 2.13.2

--- a/0.8/wheezy/Dockerfile
+++ b/0.8/wheezy/Dockerfile
@@ -3,7 +3,13 @@ FROM buildpack-deps:wheezy
 # verify gpg and sha256: http://nodejs.org/dist/v0.10.30/SHASUMS256.txt.asc
 # gpg: aka "Timothy J Fontaine (Work) <tj.fontaine@joyent.com>"
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
-RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
+RUN set -ex \
+	&& for key in \
+		7937DFD2AB06298B2293C3187D33FF9D0246406D \
+		114F43EE0176B71C7BC219DD50A3051F888C628D \
+	; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done
 
 ENV NODE_VERSION 0.8.28
 ENV NPM_VERSION 2.13.2


### PR DESCRIPTION
When "gpg" is given multiple keys, it will only exit non-zero if _all_ the keys fail to download, so sometimes we'll get this line succeeding, but a transient failure (network, keyserver, or otherwise) can cause us to get a false positive and a build that fails later at verifying binaries.

See also https://github.com/docker-library/php/pull/92 (and all the other PRs linked into that one).

(and the main reason I've made the PR is because the official build server actually ran into this scenario :disappointed: :innocent:)